### PR TITLE
Adding support for hardness to brain run selector

### DIFF
--- a/examples/fiftyone_hardness_run_examples.csv
+++ b/examples/fiftyone_hardness_run_examples.csv
@@ -1,0 +1,4 @@
+query,available_runs,selected_run
+hardness with model1 classifications,"[(key: m1_hardness, label_field: m1_classifications, hardness_field: one_hardness), (key: m2_hardness, label_field: m2_classifications, hardness_field: two_hardness)]",m1_hardness
+hardness with key 'abc',"[(key: hard, label_field: predictions, hardness_field: hard_hardness), (key: very_hard, label_field: classifications, hardness_field: very_hard_hardness), (key: abc, label_field: predictions, hardness_field: abc_hardness), (key: unknown, label_field: ground_truth, hardness_field: idk_hardness)]",abc
+sort by hardness,"[(key: hardness, label_field: my_classifications, hardness_field: hardness), (key: test, label_field: my_classes, hardness_field: hardness)]",hardness

--- a/links/brain_run_selector.py
+++ b/links/brain_run_selector.py
@@ -248,26 +248,27 @@ class TextSimilarityBrainRunSelector(BrainRunSelector):
         return brain_runs
     
     
-# class HardnessBrainRunSelector(BrainRunSelector):
-#     """Class to select the correct hardness brain run for a given query and dataset"""
+class HardnessBrainRunSelector(BrainRunSelector):
+    """Class to select the correct hardness brain run for a given query and dataset"""
 
-#     def __init__(self, dataset):
-#         super().__init__(dataset)
+    def __init__(self, dataset):
+        super().__init__(dataset)
 
-#     def set_run_type(self):
-#         self.run_type = "hardness"
+    def set_run_type(self):
+        self.run_type = "hardness"
         
-#     ## TODO: add a method to get the available brain runs for a given dataset
-#     def get_brain_run_info(self, brain_run):
-#         field = brain_run.config.uniqueness_field
-#         model = brain_run.config.model.split('.')[-1]
-#         return {"key": field, "model": model}
+    ## TODO: add a method to get the available brain runs for a given dataset
+    def get_brain_run_info(self, brain_run):
+        key = brain_run.key
+        label_field = brain_run.config.label_field
+        hardness_field = brain_run.config.hardness_field
+        return {"key": key, "label_field": label_field, "hardness_field": hardness_field}
     
-#     def get_available_brain_runs(self):
-#         brain_runs = self.dataset.list_brain_runs(method = "hardness")
-#         brain_runs = [self.dataset.get_brain_info(br) for br in brain_runs]
-#         brain_runs = [self.get_brain_run_info(br) for br in brain_runs]
-#         return brain_runs
+    def get_available_brain_runs(self):
+        brain_runs = self.dataset.list_brain_runs(method = "hardness")
+        brain_runs = [self.dataset.get_brain_info(br) for br in brain_runs]
+        brain_runs = [self.get_brain_run_info(br) for br in brain_runs]
+        return brain_runs
     
 
 brain_run_selectors = {
@@ -275,7 +276,7 @@ brain_run_selectors = {
     "mistakenness": MistakennessBrainRunSelector,
     "image_similarity": ImageSimilarityBrainRunSelector,
     "text_similarity": TextSimilarityBrainRunSelector,
-    # "hardness": HardnessBrainRunSelector
+    "hardness": HardnessBrainRunSelector
 }
 
 

--- a/testing.ipynb
+++ b/testing.ipynb
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,74 +128,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Getting or creating embeddings for queries...\n",
-      "Loading embeddings from file...\n",
-      "Saving embeddings to file...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "view_stage_examples_prompt = generate_view_stage_examples_prompt(dataset, query)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generate code to produce the FiftyOne view stages for the following prompts:\n",
-      "\n",
-      "\n",
-      "Input: 10 random images with tables\n",
-      "Output: [match(\n",
-      "    F(\"ground_truth.detections.label\").contains(\"table\")\n",
-      "), take(10)]\n",
-      "\n",
-      "Input: Take two random samples from the dataset\n",
-      "Output: [take(2)]\n",
-      "\n",
-      "Input: 10 most unique images\n",
-      "Output: [sort_by(\"uniqueness\"), limit(10)]\n",
-      "\n",
-      "Input: show me the 20 most similar imagages to the first image\n",
-      "Output: [sort_by_similarity(dataset.first().id, k=20)]\n",
-      "\n",
-      "Input: sort by similarity to image 10\n",
-      "Output: [sort_by_similarity(dataset.skip(9).id)]\n",
-      "\n",
-      "Input: Images that only contain dogs\n",
-      "Output: [match(\n",
-      "    F(\"ground_truth.detections.label\").is_subset([\"dog\"])\n",
-      ")]\n",
-      "\n",
-      "Input: take 10 random samples from the dataset with seed=51\n",
-      "Output: [take(10, seed=51)]\n",
-      "\n",
-      "Input: show me 50 random samples\n",
-      "Output: [take(50)]\n",
-      "\n",
-      "Input: show me random samples\n",
-      "Output: [shuffle()]\n",
-      "\n",
-      "Input: exclude the 8th image\n",
-      "Output: [exclude([dataset.skip(7).first().id)]\n",
-      "\n",
-      "Input: Five random images from the dataset\n",
-      "Output:\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(view_stage_examples_prompt)"
    ]
@@ -210,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,78 +172,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Here is some information about view stages you might want to use:\n",
-      "\n",
-      "\n",
-      "    View stage: take\n",
-      "    Description: Randomly samples the given number of samples from the collection\n",
-      "    Inputs: size: int (non-positive values result in an empty view), seed: optional random seed to use for sample selection\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: match\n",
-      "    Description: Filters the samples in the collection by the given filter\n",
-      "    Inputs: filter: ViewExpression or MongoDB expression that returns a boolean describing the filter to apply\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: skip\n",
-      "    Description: Omits the given number of samples from the head of the collection. Non-positive skip values result in no samples being omitted\n",
-      "    Inputs: skip: int\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: sort_by_similarity\n",
-      "    Description: Sorts the collection by similarity to a specified query\n",
-      "    Inputs: query: ID or iterable of IDs or num_dims vector or num_queries x num_dims array of vectors or text prompt or iterable of text prompts, k: int (defaults to entire collection), reverse: bool (default False), dist_field: name of float field to store distance of each example to query, brain_key: existing fiftyone.brain.compute_similarity() run on the dataset\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: exclude\n",
-      "    Description: Exclude samples with specified IDs\n",
-      "    Inputs: sample_ids: IDs to exclude. Can be single ID, iterable of IDs, Sample or SampleView instances, iterable of Sample or SampleView instances, or SampleCollection\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: limit\n",
-      "    Description: Returns a view with at most the given number of samples\n",
-      "    Inputs: limit: maximum number of samples to return. Returns an empty view if limit is non-positive\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: shuffle\n",
-      "    Description: Randomly shuffles samples in the collection\n",
-      "    Inputs: seed: optional random seed for shuffling\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: sort_by\n",
-      "    Description: Sorts samples in the collection by given field(s) or expression(s)\n",
-      "    Inputs: field_or_expr: str or ViewExpression or MongoDB aggregation expression or list of (field_or_expr, order) tuples defining a compound sort criteria, where order can be 1 for ascending or any string starting with 'a', or -1 for descending or any string starting with 'd', reverse: bool (default False)\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: exclude_by\n",
-      "    Description: Exclude samples with specified field values\n",
-      "    Inputs: field: name of the field or embedded field. values: value or iterable of values to exclude by\n",
-      "\n",
-      "    \n",
-      "\n",
-      "    View stage: exclude_fields\n",
-      "    Description: Exclude specified fields from samples\n",
-      "    Inputs: field_names: field name or iterable of field names to exclude, including embedded.field.name\n",
-      "\n",
-      "    \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(view_stage_descriptions_prompt)"
    ]
@@ -314,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,20 +198,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['uniqueness']"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"Five most unique images from the dataset\"\n",
     "select_brain_methods(query)"
@@ -344,20 +208,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['uniqueness', 'hardness']"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"50 least unique images from the dataset that were hard\"\n",
     "select_brain_methods(query)"
@@ -365,20 +218,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['mistakenness']"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"Five most mistaken images from the dataset\"\n",
     "select_brain_methods(query)"
@@ -394,39 +236,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from links.brain_run_selector import select_brain_runs"
+    "from links.brain_run_selector import select_brain_runs\n",
+    "import fiftyone.brain as fob"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import fiftyone as fo\n",
-    "dataset = fo.load_dataset(\"quickstart\")"
+    "dataset = fo.load_dataset(\"quickstart\")\n",
+    "dataset.compute_metadata()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'uniqueness': 'uniqueness1', 'image_similarity': 'img_sim'}"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "# Uncomment to create brain runs if you don't have them already\n",
+    "# fob.compute_similarity(\n",
+    "#     dataset,\n",
+    "#     model=\"clip-vit-base32-torch\",\n",
+    "#     brain_key=\"img_sim\",\n",
+    "# )\n",
+    "# fob.compute_similarity(\n",
+    "#     dataset,\n",
+    "#     patches_field=\"ground_truth\",\n",
+    "#     model=\"resnet18-imagenet-torch\",\n",
+    "#     brain_key=\"gt_sim\",\n",
+    "# )\n",
+    "# fob.compute_uniqueness(dataset)\n",
+    "\n",
+    "# fob.compute_mistakenness(dataset, \"predictions\", label_field=\"ground_truth\")\n",
+    "\n",
+    "# Create some fake classifications to make a hardness brain run\n",
+    "# import random\n",
+    "# import numpy as np\n",
+    "# classes = [\"sheep\", \"cat\", \"dog\", \"moose\"]\n",
+    "# logits = np.random.normal(size = 4)\n",
+    "# logits /= logits.sum()\n",
+    "# for sample in dataset:\n",
+    "#     sample[\"my_classifications\"] = fo.Classification(label=random.choice(classes), logits=logits, confidence=random.random())\n",
+    "#     sample.save()\n",
+    "\n",
+    "# fob.compute_hardness(dataset, label_field=\"my_classifications\")\n",
+    "# fob.compute_hardness(dataset, label_field=\"my_classifications\", hardness_field=\"test_hardness\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "query = \"most unique images from the dataset with key 'uniqueness1 that are similar to image 10\"\n",
     "select_brain_runs(dataset, query, [\"uniqueness\", \"image_similarity\"])"
@@ -434,23 +303,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'mistakenness': 'mistakenness1'}"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"Five most mistaken images from the dataset with ground truth field 'predictions\"\n",
     "select_brain_runs(dataset, query, [\"mistakenness\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"Five hardest images from dataset\"\n",
+    "select_brain_runs(dataset, query, [\"hardness\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"Hardness from key 'test_hardness'\"\n",
+    "select_brain_runs(dataset, query, [\"hardness\"])"
    ]
   },
   {
@@ -463,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,17 +360,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[predictions]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"sort pred1 by number of detections\"\n",
     "fields = select_fields(dataset, query)\n",
@@ -569,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,26 +458,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finding similar examples for query: images with tables\n",
-      "Identified likely view stages: ['match', 'sort_by_similarity', 'skip', 'exclude', 'exists', 'filter_labels', 'limit', 'select_fields', 'sort_by', 'take']\n",
-      "Identified brain methods: ['text_similarity']\n",
-      "Identified brain runs: {'text_similarity': 'clip'}\n",
-      "Identified potentially relevant fields: [ground_truth]\n",
-      "Class name table not found for label ground_truth\n",
-      "Identified label classes: {'ground_truth': ['table']}\n",
-      "[match(\n",
-      "    F(\"ground_truth.detections.label\").contains(\"table\")\n",
-      ")]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"images with tables\"\n",
     "view_text = get_gpt_view_text(dataset, query)\n",
@@ -616,21 +469,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finding similar examples for query: high confidence detections\n",
-      "Identified likely view stages: ['filter_labels', 'exists', 'match', 'filter_field', 'limit', 'match_labels', 'sort_by', 'exclude', 'exclude_by', 'exclude_fields']\n",
-      "Identified potentially relevant fields: [predictions]\n",
-      "Identified label classes: {'predictions': []}\n",
-      "[filter_labels(\"ground_truth\", F(\"confidence\") > 0.95)]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"high confidence detections\"\n",
     "view_text = get_gpt_view_text(dataset, query)\n",
@@ -639,21 +480,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finding similar examples for query: first 30 images with a ground truth detection\n",
-      "Identified likely view stages: ['match', 'sort_by_similarity', 'exists', 'filter_field', 'filter_labels', 'limit_labels', 'select_fields', 'skip', 'sort_by', 'take']\n",
-      "Identified potentially relevant fields: [ground_truth]\n",
-      "Identified label classes: {'ground_truth': []}\n",
-      "[match(F(\"ground_truth.detections\").length() > 0), take(30)]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"first 30 images with a ground truth detection\"\n",
     "view_text = get_gpt_view_text(dataset, query)\n",
@@ -828,7 +657,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.16"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
Added hardness class to brain run selector. Minimal prompts successfully choose the right key for hardness based on the given prompt.

Also added commented out code block for people running this that need to generate brain runs for uniqueness, similarity, mistakenness, and hardness.