### PR TITLE
Case sensitive class names

### DIFF
--- a/gpt_view_generator.py
+++ b/gpt_view_generator.py
@@ -104,7 +104,7 @@ def get_gpt_view_text(dataset, query, chat_history):
         dataset,
         runs,
         fields,
-        label_classes,
+        format_label_classes(label_classes),
         view_stage_descriptions,
         examples
     )
@@ -131,9 +131,10 @@ from IPython.display import clear_output
 def gpt(dataset):
     chat_history = []
     session = fo.launch_app(dataset, auto = False)
+    print("Hello! I'm here to help you explore your datasets.\nMy reponses are based off of our chat history. To clear my history and restart, enter 'reset'.\n")
     while True:
         clear_output(True)
-        input_text = "Hello! I'm here to help you explore your datasets.\nMy reponses are based off of our chat history. To clear my history and restart, enter 'reset'.\nHow can I help you? "
+        input_text = "How can I help you? "
         if len(chat_history) == 0:
             log_chat_history(input_text, "GPT", chat_history)
         query = input(input_text)

--- a/links/dataset_view_generator.py
+++ b/links/dataset_view_generator.py
@@ -62,7 +62,7 @@ def generate_evaluation_prompt(dataset, eval_key):
 
     if f"{eval_key}_tp" in field_names:
         prompt += EVAL_FIELDS_PROMPT_TEMPLATE.format(eval_tp_field=f"{eval_key}_tp", eval_fp_field=f"{eval_key}_fp", eval_fn_field=f"{eval_key}_fn")
-    
+
     return prompt
 
 
@@ -76,7 +76,7 @@ def generate_mistakenness_prompt(dataset, brain_key):
     missing_field = brc.missing_field
     if missing_field in field_names:
         prompt += missing_field_prompt.format(missing_field=missing_field)
-    
+
     spurious_field = brc.spurious_field
     if spurious_field in field_names:
         prompt += spurious_field_prompt.format(spurious_field=spurious_field)
@@ -107,7 +107,7 @@ def generate_runs_prompt(dataset, runs):
     ## If there are no runs, return an empty string
     if len(runs) == 0:
         return ""
-    
+
     header = "Here is the relevant information about the runs that were run on this dataset:\n"
     prompt = header
 
@@ -208,7 +208,7 @@ def split_into_stages(stages_text):
     st = stages_text[1:-1].replace(', ', ',').replace('\n', '')
     st = st.replace('\r', '').replace('\'', "\"")
     x = re.finditer(pattern, st)
-    
+
     stages = []
     spans = []
     for match in x:
@@ -252,6 +252,6 @@ def get_gpt_view_stage_strings(
     if '_MORE_' in response:
         return '_MORE_'
     elif "_CONFUSED_" in response:
-        return "_CONFUSED_" 
+        return "_CONFUSED_"
     else:
         return split_into_stages(response)

--- a/prompts/dataset_view_generator_prefix.txt
+++ b/prompts/dataset_view_generator_prefix.txt
@@ -12,5 +12,5 @@ Here are some rules:
 - you can use any ViewExpression, with the ViewField as F
 - If you think you need more information, or believe the input is incomplete, you must respond with the string '_MORE_'.
 - If you are confused, or believe the input is corrupted or incoherent, respond with the string '_CONFUSED_'.
-- In your response, you can use the runs specified below. In addition, you can use these and only these fields: {available_fields}, and these and only these label classes: {label_classes}. You do not need to use all of these label fields or classes. You may NOT use any other fields or classes. 
+- In your response, you can use the runs specified below. In addition, you can use these and only these fields: {available_fields}, and these and only these label classes: {label_classes}. You do not need to use all of these label fields or classes. You may NOT use any other fields or classes. These fields and classes are case sensitive. 
  


### PR DESCRIPTION
Problem: 
On open images, the prompt "show me keypoints for images with dogs" resulted in an expression that included the class `dog` rather than `Dog`, even though the label class that was provided included `Dog` uppercase.

Changes:
* Provide formatted class labels in the view generation prompt
* Update the view generator prompt to specify case sensitivity
* Other: Update the input text to only mention resetting once