### PR TITLE
LangChain Upgrade

### DIFF
--- a/links/docs_query_dispatcher.py
+++ b/links/docs_query_dispatcher.py
@@ -200,7 +200,7 @@ def _generate_docs_embeddings():
         pickle.dump(api_embeddings_dict, f)
 
 
-class FiftyOneDocsRetriever(BaseRetriever):
+class FiftyOneDocsRetriever:
     def __init__(self, embeddings):
         self.model = get_embedding_function()
         self.contents = [


### PR DESCRIPTION
LangChain upgraded their `BaseRetriever` class to Pydantic, which made our child class `FiftyOneDocsRetriever` throw an error when trying to add custom attributes. The fix was to just get rid of the inheritance. `FiftyOneDocsRetriever` still implements the `get_relevant_documents()` method as before.

Test that now works:

```
from voxelgpt import ask_voxelgpt
ask_voxelgpt("does fiftyone support 3d bounding boxes?")
```

Also verified that CV queries and basic dataset queries still work. 

Test conducted with `langchain==0.0.179` (old version)  and `langchain==0.0.288` (most recent), plus some intermediate versions, and all work.