### PR TITLE
Backwards-compatible secrets check

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -401,7 +401,11 @@ def deserialize_view(dataset, stages):
 
 
 def inject_voxelgpt_secrets(ctx):
-    api_key = ctx.secret("OPENAI_API_KEY")
+    try:
+        api_key = ctx.secrets["OPENAI_API_KEY"]
+    except:
+        api_key = None
+
     if api_key:
         os.environ["OPENAI_API_KEY"] = api_key
 


### PR DESCRIPTION
One of two things needs to happen:
1. Make this change so that this plugin continues to be backwards-compatible with pre-secret versions of FO, as claimed by the `fiftyone.yml`
2. Update `fiftyone.yml` to document that this plugin now requires a version of FO that supports `ctx.secret`

Since this change is simple, I suggest Option 1 😄 